### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled command line

### DIFF
--- a/myocyte/toxtempass/__init__.py
+++ b/myocyte/toxtempass/__init__.py
@@ -1,6 +1,8 @@
 # ruff: noqa: W293, W291, E501
 import logging
 import os
+from types import MappingProxyType
+from typing import Final, Mapping
 
 from django.conf import settings
 
@@ -144,18 +146,17 @@ class Config:
             ]
         ]
     )
-    image_accept_files = [".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp"]
-    text_accept_files = [
-        ".pdf",
-        ".docx",
-        ".txt",
-        ".md",
-        ".html",
-        ".json",
-        ".csv",
-        ".xlsx",
-    ]
-    allowed_mime_types = [
+    # ── Upload control surface ────────────────────────────────────────────────
+    # What users may upload: image/text suffixes drive the HTML `accept=` hint,
+    # ALLOWED_MIME_TYPES gates server-side validation. Immutable containers so
+    # these can't be mutated at runtime from anywhere in the app.
+    IMAGE_ACCEPT_FILES: Final[tuple[str, ...]] = (
+        ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp",
+    )
+    TEXT_ACCEPT_FILES: Final[tuple[str, ...]] = (
+        ".pdf", ".docx", ".txt", ".md", ".html", ".json", ".csv", ".xlsx",
+    )
+    ALLOWED_MIME_TYPES: Final[frozenset[str]] = frozenset({
         "application/pdf",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "application/msword",
@@ -171,7 +172,37 @@ class Config:
         "application/json",
         "text/csv",
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    ]
+    })
+
+    # ── Export control surface ────────────────────────────────────────────────
+    # What the app may export: EXPORT_MIME_SUFFIX gives MIME + filename suffix
+    # per type, EXPORT_MAPPING gives the trusted Pandoc options. Security-
+    # relevant: adding a new export type means adding an entry here and nowhere
+    # else. MappingProxyType makes the mappings read-only at runtime — `Final`
+    # and the `Mapping` hint alone only guard rebinding / static-type mistakes,
+    # not `Config.EXPORT_MAPPING["pdf"] = (...)` at runtime.
+    _mime_type_docx = (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
+    EXPORT_MIME_SUFFIX: Final[Mapping[str, Mapping[str, str]]] = MappingProxyType({
+        "html": MappingProxyType({"mime_type": "text/html", "suffix": ".html"}),
+        "xml": MappingProxyType({"mime_type": "application/xml", "suffix": ".xml"}),
+        "pdf": MappingProxyType({"mime_type": "application/pdf", "suffix": ".pdf"}),
+        "docx": MappingProxyType({"mime_type": _mime_type_docx, "suffix": ".docx"}),
+        "json": MappingProxyType({"mime_type": "application/json", "suffix": ".json"}),
+        "md": MappingProxyType({"mime_type": "text/markdown", "suffix": ".md"}),
+    })
+    EXPORT_MAPPING: Final[Mapping[str, tuple[str, ...]]] = MappingProxyType({
+        "json": (),
+        "md": ("--to=gfm+smart",),
+        "pdf": ("--pdf-engine=lualatex", "--standalone"),
+        "docx": ("--to=docx+auto_identifiers",),
+        "html": ("--embed-resources", "--standalone", "--to=html5+smart"),
+        "xml": ("--to=docbook",),
+    })
+    # Subset of EXPORT_MAPPING types that require Pandoc (JSON is serialized inline).
+    PANDOC_EXPORT_TYPES: Final[frozenset[str]] = frozenset(EXPORT_MAPPING) - {"json"}
+
     license_url = "https://www.gnu.org/licenses/agpl-3.0.html"
     version = os.getenv("GIT_TAG", "") + "-beta"
     reference_toxtempassistant_zenodo_code = "https://doi.org/10.5281/zenodo.15607642"
@@ -188,11 +219,7 @@ class Config:
     max_workers_django_q = settings.Q_CLUSTER[
         "workers"
     ]  # 1 worker for django_q, we use threading for parallelism
-    # this is just for security purposes, to add a new type you also need to
-    # define a template for it in export.py
-    allowed_export_types = {"json", "md", "pdf", "html", "docx", "xml"}
-    
-    # How often to reload the overview page to check for busy/scheduled assays 
+    # How often to reload the overview page to check for busy/scheduled assays
     # (in milliseconds)
     reload_busy_interval_seconds = 10000
     reload_busy_max_retries = 30  # e.g., 30 × 10s = 5 minutes

--- a/myocyte/toxtempass/export.py
+++ b/myocyte/toxtempass/export.py
@@ -277,34 +277,31 @@ def export_assay_to_file(
     export_mapping = {
         "json": {
             "pandoc_opts": [],
-            "ext": "json"
         },
         "md": {
             "pandoc_opts": ["--to=gfm+smart"],
-            "ext": "md"
         },
         "pdf": {
             "pandoc_opts": ["--pdf-engine=lualatex", "--standalone"],
-            "ext": "pdf"
         },
         "docx": {
             "pandoc_opts": ["--to=docx+auto_identifiers"],
-            "ext": "docx"
         },
         "html": {
             "pandoc_opts": ["--embed-resources", "--standalone", "--to=html5+smart"],
-            "ext": "html"
         },
         "xml": {
             "pandoc_opts": ["--to=docbook"],
-            "ext": "xml"
         },
     }
-    # Only use mapped extension
-    if export_type not in export_mapping:
+    # Only use export types with both trusted options and known MIME/suffix metadata
+    if (
+        export_type not in export_mapping
+        or export_type not in mime_type_suffix_dict
+    ):
         return JsonResponse({"error": "Invalid export type"}, status=400)
-    mapped_ext = export_mapping[export_type]["ext"]
-    file_name = f"toxtemp_{slugify(assay.title)}.{mapped_ext}"
+    mapped_suffix = mime_type_suffix_dict[export_type]["suffix"]
+    file_name = f"toxtemp_{slugify(assay.title)}.{mapped_suffix}"
     file_path = Path(settings.MEDIA_ROOT) / "toxtempass" / file_name  # Use pathlib.Path
     if not file_path.parent.exists():
         file_path.parent.mkdir(parents=True)

--- a/myocyte/toxtempass/export.py
+++ b/myocyte/toxtempass/export.py
@@ -2,6 +2,7 @@ import json
 import re
 import subprocess
 from pathlib import Path
+from typing import Final
 
 import yaml
 from django.core.serializers import serialize
@@ -59,6 +60,17 @@ mime_type_suffix_dict = {
     },
     "json": {"mime_type": "application/json", "suffix": ".json"},
     "md": {"mime_type": "text/markdown", "suffix": ".md"},
+}
+
+# Module-level mapping of allowed export types to trusted Pandoc options.
+# Extensions are derived from mime_type_suffix_dict to keep a single source of truth.
+EXPORT_MAPPING: Final[dict[str, list[str]]] = {
+    "json": [],
+    "md": ["--to=gfm+smart"],
+    "pdf": ["--pdf-engine=lualatex", "--standalone"],
+    "docx": ["--to=docx+auto_identifiers"],
+    "html": ["--embed-resources", "--standalone", "--to=html5+smart"],
+    "xml": ["--to=docbook"],
 }
 
 
@@ -273,35 +285,11 @@ def export_assay_to_file(
     """Export assay to file."""
     if export_type not in getattr(Config, "allowed_export_types", []):
         return JsonResponse({"error": "Invalid export type"}, status=400)
-    # Use explicit mapping for allowed export types
-    export_mapping = {
-        "json": {
-            "pandoc_opts": [],
-        },
-        "md": {
-            "pandoc_opts": ["--to=gfm+smart"],
-        },
-        "pdf": {
-            "pandoc_opts": ["--pdf-engine=lualatex", "--standalone"],
-        },
-        "docx": {
-            "pandoc_opts": ["--to=docx+auto_identifiers"],
-        },
-        "html": {
-            "pandoc_opts": ["--embed-resources", "--standalone", "--to=html5+smart"],
-        },
-        "xml": {
-            "pandoc_opts": ["--to=docbook"],
-        },
-    }
     # Only use export types with both trusted options and known MIME/suffix metadata
-    if (
-        export_type not in export_mapping
-        or export_type not in mime_type_suffix_dict
-    ):
+    if export_type not in EXPORT_MAPPING or export_type not in mime_type_suffix_dict:
         return JsonResponse({"error": "Invalid export type"}, status=400)
     mapped_suffix = mime_type_suffix_dict[export_type]["suffix"]
-    file_name = f"toxtemp_{slugify(assay.title)}.{mapped_suffix}"
+    file_name = f"toxtemp_{slugify(assay.title)}{mapped_suffix}"
     file_path = Path(settings.MEDIA_ROOT) / "toxtempass" / file_name  # Use pathlib.Path
     if not file_path.parent.exists():
         file_path.parent.mkdir(parents=True)
@@ -335,7 +323,7 @@ def export_assay_to_file(
             "--toc",
         ]
         # Add ONLY safe mapped Pandoc options
-        pandoc_command.extend(export_mapping[export_type]["pandoc_opts"])
+        pandoc_command.extend(EXPORT_MAPPING[export_type])
         pandoc_command.extend(["-o", str(file_path)])
 
         try:

--- a/myocyte/toxtempass/export.py
+++ b/myocyte/toxtempass/export.py
@@ -273,7 +273,38 @@ def export_assay_to_file(
     """Export assay to file."""
     if export_type not in getattr(Config, "allowed_export_types", []):
         return JsonResponse({"error": "Invalid export type"}, status=400)
-    file_name = f"toxtemp_{slugify(assay.title)}.{export_type}"
+    # Use explicit mapping for allowed export types
+    export_mapping = {
+        "json": {
+            "pandoc_opts": [],
+            "ext": "json"
+        },
+        "md": {
+            "pandoc_opts": ["--to=gfm+smart"],
+            "ext": "md"
+        },
+        "pdf": {
+            "pandoc_opts": ["--pdf-engine=lualatex", "--standalone"],
+            "ext": "pdf"
+        },
+        "docx": {
+            "pandoc_opts": ["--to=docx+auto_identifiers"],
+            "ext": "docx"
+        },
+        "html": {
+            "pandoc_opts": ["--embed-resources", "--standalone", "--to=html5+smart"],
+            "ext": "html"
+        },
+        "xml": {
+            "pandoc_opts": ["--to=docbook"],
+            "ext": "xml"
+        },
+    }
+    # Only use mapped extension
+    if export_type not in export_mapping:
+        return JsonResponse({"error": "Invalid export type"}, status=400)
+    mapped_ext = export_mapping[export_type]["ext"]
+    file_name = f"toxtemp_{slugify(assay.title)}.{mapped_ext}"
     file_path = Path(settings.MEDIA_ROOT) / "toxtempass" / file_name  # Use pathlib.Path
     if not file_path.parent.exists():
         file_path.parent.mkdir(parents=True)
@@ -303,27 +334,11 @@ def export_assay_to_file(
             "pandoc",
             str(md_file_path),
             "--from=markdown+tex_math_dollars+tex_math_single_backslash+tex_math_double_backslash",
-            # Add standalone option for HTML and PDF
-            # also defines latex packages
             f"--metadata-file={str(yaml_metadata_file_path)}",
             "--toc",
         ]
-
-        # Add specific options based on the export type
-        if export_type == "pdf":
-            # Specify PDF engine if needed
-            pandoc_command.extend(["--pdf-engine=lualatex", "--standalone"])
-        if export_type == "md":
-            pandoc_command.append("--to=gfm+smart")
-        if export_type == "docx":
-            pandoc_command.append("--to=docx+auto_identifiers")
-        elif export_type == "html":
-            pandoc_command.extend(
-                ["--embed-resources", "--standalone", "--to=html5+smart"]
-            )
-        # Add any additional HTML-specific options if needed
-        # pandoc_command.append("--self-contained")  # Optionally make it self-contained
-
+        # Add ONLY safe mapped Pandoc options
+        pandoc_command.extend(export_mapping[export_type]["pandoc_opts"])
         pandoc_command.extend(["-o", str(file_path)])
 
         try:

--- a/myocyte/toxtempass/export.py
+++ b/myocyte/toxtempass/export.py
@@ -2,7 +2,6 @@ import json
 import re
 import subprocess
 from pathlib import Path
-from typing import Final, Mapping
 
 import yaml
 from django.core.serializers import serialize
@@ -11,8 +10,14 @@ from django.utils import timezone  # Import timezone utilities
 from django.utils.text import slugify
 
 from myocyte import settings
-from toxtempass import Config  # Import your configuration module
+from toxtempass import Config
 from toxtempass.models import Assay, Section
+
+# Export control surface lives on Config (see toxtempass/__init__.py). These
+# module-level aliases keep call sites terse and let tests patch them.
+EXPORT_MIME_SUFFIX = Config.EXPORT_MIME_SUFFIX
+EXPORT_MAPPING = Config.EXPORT_MAPPING
+PANDOC_EXPORT_TYPES = Config.PANDOC_EXPORT_TYPES
 
 # simple regexes to catch display‐math delimiters
 
@@ -47,36 +52,6 @@ def quote_answer(text: str) -> str:
         out.append(f"> {line}" if line.strip() else ">")  # keep blank lines too
 
     return "\n".join(out) + "\n\n"
-
-
-mime_type_str = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-mime_type_suffix_dict = {
-    "html": {"mime_type": "text/html", "suffix": ".html"},
-    "xml": {"mime_type": "application/xml", "suffix": ".xml"},
-    "pdf": {"mime_type": "application/pdf", "suffix": ".pdf"},
-    "docx": {
-        "mime_type": mime_type_str,
-        "suffix": ".docx",
-    },
-    "json": {"mime_type": "application/json", "suffix": ".json"},
-    "md": {"mime_type": "text/markdown", "suffix": ".md"},
-}
-
-# Module-level mapping of allowed export types to trusted Pandoc options.
-# Extensions are derived from mime_type_suffix_dict to keep a single source of truth.
-# Immutable containers (tuples + Mapping) prevent accidental runtime mutation.
-EXPORT_MAPPING: Final[Mapping[str, tuple[str, ...]]] = {
-    "json": (),
-    "md": ("--to=gfm+smart",),
-    "pdf": ("--pdf-engine=lualatex", "--standalone"),
-    "docx": ("--to=docx+auto_identifiers",),
-    "html": ("--embed-resources", "--standalone", "--to=html5+smart"),
-    "xml": ("--to=docbook",),
-}
-
-# Subset of EXPORT_MAPPING types that require Pandoc conversion.
-# Derived from the mapping so adding a new Pandoc format is a one-place change.
-PANDOC_EXPORT_TYPES: Final[frozenset[str]] = frozenset(EXPORT_MAPPING) - {"json"}
 
 
 def generate_json_from_assay(assay: Assay) -> dict | None:
@@ -288,12 +263,12 @@ def export_assay_to_file(
     request: HttpRequest, assay: Assay, export_type: str
 ) -> FileResponse:
     """Export assay to file."""
-    if export_type not in getattr(Config, "allowed_export_types", []):
+    # EXPORT_MAPPING (defined in toxtempass/__init__.py) is the single security
+    # gate: only types with both trusted Pandoc options and known MIME/suffix
+    # metadata are permitted.
+    if export_type not in EXPORT_MAPPING or export_type not in EXPORT_MIME_SUFFIX:
         return JsonResponse({"error": "Invalid export type"}, status=400)
-    # Only use export types with both trusted options and known MIME/suffix metadata
-    if export_type not in EXPORT_MAPPING or export_type not in mime_type_suffix_dict:
-        return JsonResponse({"error": "Invalid export type"}, status=400)
-    mapped_suffix = mime_type_suffix_dict[export_type]["suffix"]
+    mapped_suffix = EXPORT_MIME_SUFFIX[export_type]["suffix"]
     file_name = f"toxtemp_{slugify(assay.title)}{mapped_suffix}"
     file_path = Path(settings.MEDIA_ROOT) / "toxtempass" / file_name  # Use pathlib.Path
     if not file_path.parent.exists():
@@ -359,7 +334,7 @@ def export_assay_to_file(
             file_path.open("rb"),
             as_attachment=True,
             filename=file_name,
-            content_type=mime_type_suffix_dict[export_type]["mime_type"],
+            content_type=EXPORT_MIME_SUFFIX[export_type]["mime_type"],
         )
         return response
     except Exception:

--- a/myocyte/toxtempass/export.py
+++ b/myocyte/toxtempass/export.py
@@ -2,7 +2,7 @@ import json
 import re
 import subprocess
 from pathlib import Path
-from typing import Final
+from typing import Final, Mapping
 
 import yaml
 from django.core.serializers import serialize
@@ -64,14 +64,19 @@ mime_type_suffix_dict = {
 
 # Module-level mapping of allowed export types to trusted Pandoc options.
 # Extensions are derived from mime_type_suffix_dict to keep a single source of truth.
-EXPORT_MAPPING: Final[dict[str, list[str]]] = {
-    "json": [],
-    "md": ["--to=gfm+smart"],
-    "pdf": ["--pdf-engine=lualatex", "--standalone"],
-    "docx": ["--to=docx+auto_identifiers"],
-    "html": ["--embed-resources", "--standalone", "--to=html5+smart"],
-    "xml": ["--to=docbook"],
+# Immutable containers (tuples + Mapping) prevent accidental runtime mutation.
+EXPORT_MAPPING: Final[Mapping[str, tuple[str, ...]]] = {
+    "json": (),
+    "md": ("--to=gfm+smart",),
+    "pdf": ("--pdf-engine=lualatex", "--standalone"),
+    "docx": ("--to=docx+auto_identifiers",),
+    "html": ("--embed-resources", "--standalone", "--to=html5+smart"),
+    "xml": ("--to=docbook",),
 }
+
+# Subset of EXPORT_MAPPING types that require Pandoc conversion.
+# Derived from the mapping so adding a new Pandoc format is a one-place change.
+PANDOC_EXPORT_TYPES: Final[frozenset[str]] = frozenset(EXPORT_MAPPING) - {"json"}
 
 
 def generate_json_from_assay(assay: Assay) -> dict | None:
@@ -305,7 +310,7 @@ def export_assay_to_file(
     #     with file_path.open("w", encoding="utf-8") as md_file:
     #         md_file.write(export_data)
 
-    elif export_type in ["md", "pdf", "html", "docx", "xml"]:
+    elif export_type in PANDOC_EXPORT_TYPES:
         # Generate the markdown file
         export_data = generate_markdown_from_assay(assay)
         md_file_path = (file_path.with_name(f"{file_path.stem}_md")).with_suffix(".md")

--- a/myocyte/toxtempass/filehandling.py
+++ b/myocyte/toxtempass/filehandling.py
@@ -492,7 +492,7 @@ def get_text_or_bytes_perfile_dict(
             elif suffix == ".xlsx":
                 text = _read_xlsx_file(context_filename)
 
-            elif suffix in config.image_accept_files:
+            elif suffix in config.IMAGE_ACCEPT_FILES:
                 # Convert all uploaded images to WebP for optimal token efficiency
                 with open(context_filename, "rb") as img_file:
                     image_bytes = img_file.read()

--- a/myocyte/toxtempass/forms.py
+++ b/myocyte/toxtempass/forms.py
@@ -475,7 +475,7 @@ class AssayAnswerForm(forms.Form):
             raise PermissionDenied("You do not have access to this assay.")
         super().__init__(*args, **kwargs)
 
-        accepted_files = ",".join(config.image_accept_files + config.text_accept_files)
+        accepted_files = ",".join(config.IMAGE_ACCEPT_FILES + config.TEXT_ACCEPT_FILES)
         self.fields["file_upload"] = MultipleFileField(
             widget=MultipleFileInput(
                 attrs={
@@ -563,7 +563,7 @@ class AssayAnswerForm(forms.Form):
         if not files:
             return []
 
-        allowed_types = config.allowed_mime_types
+        allowed_types = config.ALLOWED_MIME_TYPES
         max_size_bytes = int(config.max_size_mb * 1024 * 1024)
 
         errors: list[forms.ValidationError] = []

--- a/myocyte/toxtempass/tests/test_export_security.py
+++ b/myocyte/toxtempass/tests/test_export_security.py
@@ -11,6 +11,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from django.http import FileResponse
 from django.test import TestCase
 
 from toxtempass import Config
@@ -19,6 +20,18 @@ from toxtempass.tests.fixtures.factories import AssayFactory, PersonFactory
 EXPORT_MAPPING = Config.EXPORT_MAPPING
 EXPORT_MIME_SUFFIX = Config.EXPORT_MIME_SUFFIX
 PANDOC_EXPORT_TYPES = Config.PANDOC_EXPORT_TYPES
+
+
+def _release_file_response(response: FileResponse) -> None:
+    """Close the underlying file handle without firing request_finished.
+
+    We must close the FD so TemporaryDirectory can clean up (Windows) and to
+    avoid leaking across the loop, but calling response.close() fires
+    django.core.signals.request_finished, whose close_old_connections
+    listener closes the DB connection shared by this TestCase and poisons
+    the next setUp. file_to_stream is FileResponse's public stream attribute.
+    """
+    response.file_to_stream.close()
 
 
 def _make_pandoc_stub(captured_commands: list) -> object:
@@ -57,7 +70,7 @@ class ExportFilenameTests(TestCase):
                 mock_settings.MEDIA_ROOT = tmp_dir
                 response = export_assay_to_file(self.request, self.assay, "json")
             content_disp = response.headers.get("Content-Disposition", "")
-            response.close()
+            _release_file_response(response)
 
         expected_suffix = EXPORT_MIME_SUFFIX["json"]["suffix"]  # ".json"
         self.assertIn(expected_suffix, content_disp)
@@ -97,7 +110,7 @@ class ExportFilenameTests(TestCase):
                         self.request, self.assay, export_type
                     )
                 content_disp = response.headers.get("Content-Disposition", "")
-                response.close()
+                _release_file_response(response)
 
                 expected_suffix = EXPORT_MIME_SUFFIX[export_type]["suffix"]
                 self.assertIn(
@@ -150,7 +163,7 @@ class ExportPandocCommandTests(TestCase):
                 ):
                     mock_settings.MEDIA_ROOT = tmp_dir
                     response = export_assay_to_file(self.request, self.assay, export_type)
-                response.close()
+                _release_file_response(response)
 
                 self.assertEqual(
                     len(captured_commands),

--- a/myocyte/toxtempass/tests/test_export_security.py
+++ b/myocyte/toxtempass/tests/test_export_security.py
@@ -56,9 +56,10 @@ class ExportFilenameTests(TestCase):
             ):
                 mock_settings.MEDIA_ROOT = tmp_dir
                 response = export_assay_to_file(self.request, self.assay, "json")
+            content_disp = response.headers.get("Content-Disposition", "")
+            response.close()
 
         expected_suffix = EXPORT_MIME_SUFFIX["json"]["suffix"]  # ".json"
-        content_disp = response.headers.get("Content-Disposition", "")
         self.assertIn(expected_suffix, content_disp)
         # Guard against a double-dot regression (e.g. "toxtemp_title..json")
         self.assertNotIn("..", content_disp)
@@ -95,9 +96,10 @@ class ExportFilenameTests(TestCase):
                     response = export_assay_to_file(
                         self.request, self.assay, export_type
                     )
+                content_disp = response.headers.get("Content-Disposition", "")
+                response.close()
 
                 expected_suffix = EXPORT_MIME_SUFFIX[export_type]["suffix"]
-                content_disp = response.headers.get("Content-Disposition", "")
                 self.assertIn(
                     expected_suffix,
                     content_disp,
@@ -147,7 +149,8 @@ class ExportPandocCommandTests(TestCase):
                     ),
                 ):
                     mock_settings.MEDIA_ROOT = tmp_dir
-                    export_assay_to_file(self.request, self.assay, export_type)
+                    response = export_assay_to_file(self.request, self.assay, export_type)
+                response.close()
 
                 self.assertEqual(
                     len(captured_commands),

--- a/myocyte/toxtempass/tests/test_export_security.py
+++ b/myocyte/toxtempass/tests/test_export_security.py
@@ -1,7 +1,7 @@
 """Regression tests: export_assay_to_file security hardening.
 
 Verifies that:
-1. Exported filenames use only the hardcoded suffix from mime_type_suffix_dict,
+1. Exported filenames use only the hardcoded suffix from EXPORT_MIME_SUFFIX,
    not raw export_type string concatenation.
 2. The Pandoc subprocess command contains only trusted options from EXPORT_MAPPING
    and never includes raw export_type values as standalone arguments.
@@ -13,8 +13,12 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
-from toxtempass.export import EXPORT_MAPPING, PANDOC_EXPORT_TYPES, mime_type_suffix_dict
+from toxtempass import Config
 from toxtempass.tests.fixtures.factories import AssayFactory, PersonFactory
+
+EXPORT_MAPPING = Config.EXPORT_MAPPING
+EXPORT_MIME_SUFFIX = Config.EXPORT_MIME_SUFFIX
+PANDOC_EXPORT_TYPES = Config.PANDOC_EXPORT_TYPES
 
 
 def _make_pandoc_stub(captured_commands: list) -> object:
@@ -32,7 +36,7 @@ def _make_pandoc_stub(captured_commands: list) -> object:
 
 
 class ExportFilenameTests(TestCase):
-    """Filename suffix is derived from mime_type_suffix_dict, not raw export_type."""
+    """Filename suffix is derived from EXPORT_MIME_SUFFIX, not raw export_type."""
 
     def setUp(self):
         self.user = PersonFactory()
@@ -40,29 +44,27 @@ class ExportFilenameTests(TestCase):
         self.request = MagicMock()
 
     def test_json_filename_suffix_from_mapping(self):
-        """JSON export filename ends with the suffix from mime_type_suffix_dict."""
+        """JSON export filename ends with the suffix from EXPORT_MIME_SUFFIX."""
         from toxtempass.export import export_assay_to_file
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             with (
                 patch("toxtempass.export.settings") as mock_settings,
-                patch("toxtempass.export.Config") as mock_config,
                 patch(
                     "toxtempass.export.generate_json_from_assay", return_value={}
                 ),
             ):
                 mock_settings.MEDIA_ROOT = tmp_dir
-                mock_config.allowed_export_types = list(EXPORT_MAPPING.keys())
                 response = export_assay_to_file(self.request, self.assay, "json")
 
-        expected_suffix = mime_type_suffix_dict["json"]["suffix"]  # ".json"
+        expected_suffix = EXPORT_MIME_SUFFIX["json"]["suffix"]  # ".json"
         content_disp = response.headers.get("Content-Disposition", "")
         self.assertIn(expected_suffix, content_disp)
         # Guard against a double-dot regression (e.g. "toxtemp_title..json")
         self.assertNotIn("..", content_disp)
 
     def test_pandoc_filename_suffix_from_mapping(self):
-        """Every Pandoc export type uses the suffix from mime_type_suffix_dict."""
+        """Every Pandoc export type uses the suffix from EXPORT_MIME_SUFFIX."""
         from toxtempass.export import export_assay_to_file
 
         for export_type in PANDOC_EXPORT_TYPES:
@@ -76,7 +78,6 @@ class ExportFilenameTests(TestCase):
 
                 with (
                     patch("toxtempass.export.settings") as mock_settings,
-                    patch("toxtempass.export.Config") as mock_config,
                     patch(
                         "toxtempass.export.generate_markdown_from_assay",
                         return_value="# test",
@@ -91,12 +92,11 @@ class ExportFilenameTests(TestCase):
                     ),
                 ):
                     mock_settings.MEDIA_ROOT = tmp_dir
-                    mock_config.allowed_export_types = list(EXPORT_MAPPING.keys())
                     response = export_assay_to_file(
                         self.request, self.assay, export_type
                     )
 
-                expected_suffix = mime_type_suffix_dict[export_type]["suffix"]
+                expected_suffix = EXPORT_MIME_SUFFIX[export_type]["suffix"]
                 content_disp = response.headers.get("Content-Disposition", "")
                 self.assertIn(
                     expected_suffix,
@@ -133,7 +133,6 @@ class ExportPandocCommandTests(TestCase):
 
                 with (
                     patch("toxtempass.export.settings") as mock_settings,
-                    patch("toxtempass.export.Config") as mock_config,
                     patch(
                         "toxtempass.export.generate_markdown_from_assay",
                         return_value="# test",
@@ -148,7 +147,6 @@ class ExportPandocCommandTests(TestCase):
                     ),
                 ):
                     mock_settings.MEDIA_ROOT = tmp_dir
-                    mock_config.allowed_export_types = list(EXPORT_MAPPING.keys())
                     export_assay_to_file(self.request, self.assay, export_type)
 
                 self.assertEqual(

--- a/myocyte/toxtempass/tests/test_export_security.py
+++ b/myocyte/toxtempass/tests/test_export_security.py
@@ -1,0 +1,175 @@
+"""Regression tests: export_assay_to_file security hardening.
+
+Verifies that:
+1. Exported filenames use only the hardcoded suffix from mime_type_suffix_dict,
+   not raw export_type string concatenation.
+2. The Pandoc subprocess command contains only trusted options from EXPORT_MAPPING
+   and never includes raw export_type values as standalone arguments.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from toxtempass.export import EXPORT_MAPPING, PANDOC_EXPORT_TYPES, mime_type_suffix_dict
+from toxtempass.tests.fixtures.factories import AssayFactory, PersonFactory
+
+
+def _make_pandoc_stub(captured_commands: list) -> object:
+    """Return a side_effect callable that records the command and touches the output file."""
+
+    def _run(cmd, check=False):
+        captured_commands.append(list(cmd))
+        try:
+            o_idx = cmd.index("-o")
+            Path(cmd[o_idx + 1]).touch()
+        except ValueError:
+            pass
+
+    return _run
+
+
+class ExportFilenameTests(TestCase):
+    """Filename suffix is derived from mime_type_suffix_dict, not raw export_type."""
+
+    def setUp(self):
+        self.user = PersonFactory()
+        self.assay = AssayFactory(title="my test assay")
+        self.request = MagicMock()
+
+    def test_json_filename_suffix_from_mapping(self):
+        """JSON export filename ends with the suffix from mime_type_suffix_dict."""
+        from toxtempass.export import export_assay_to_file
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with (
+                patch("toxtempass.export.settings") as mock_settings,
+                patch("toxtempass.export.Config") as mock_config,
+                patch(
+                    "toxtempass.export.generate_json_from_assay", return_value={}
+                ),
+            ):
+                mock_settings.MEDIA_ROOT = tmp_dir
+                mock_config.allowed_export_types = list(EXPORT_MAPPING.keys())
+                response = export_assay_to_file(self.request, self.assay, "json")
+
+        expected_suffix = mime_type_suffix_dict["json"]["suffix"]  # ".json"
+        content_disp = response.headers.get("Content-Disposition", "")
+        self.assertIn(expected_suffix, content_disp)
+        # Guard against a double-dot regression (e.g. "toxtemp_title..json")
+        self.assertNotIn("..", content_disp)
+
+    def test_pandoc_filename_suffix_from_mapping(self):
+        """Every Pandoc export type uses the suffix from mime_type_suffix_dict."""
+        from toxtempass.export import export_assay_to_file
+
+        for export_type in PANDOC_EXPORT_TYPES:
+            with (
+                self.subTest(export_type=export_type),
+                tempfile.TemporaryDirectory() as tmp_dir,
+            ):
+                yaml_stub = Path(tmp_dir) / "meta.yaml"
+                yaml_stub.write_text("title: test")
+                captured_commands: list = []
+
+                with (
+                    patch("toxtempass.export.settings") as mock_settings,
+                    patch("toxtempass.export.Config") as mock_config,
+                    patch(
+                        "toxtempass.export.generate_markdown_from_assay",
+                        return_value="# test",
+                    ),
+                    patch(
+                        "toxtempass.export.get_create_meta_data_yaml",
+                        return_value=yaml_stub,
+                    ),
+                    patch(
+                        "toxtempass.export.subprocess.run",
+                        side_effect=_make_pandoc_stub(captured_commands),
+                    ),
+                ):
+                    mock_settings.MEDIA_ROOT = tmp_dir
+                    mock_config.allowed_export_types = list(EXPORT_MAPPING.keys())
+                    response = export_assay_to_file(
+                        self.request, self.assay, export_type
+                    )
+
+                expected_suffix = mime_type_suffix_dict[export_type]["suffix"]
+                content_disp = response.headers.get("Content-Disposition", "")
+                self.assertIn(
+                    expected_suffix,
+                    content_disp,
+                    msg=f"Expected suffix '{expected_suffix}' for type '{export_type}'",
+                )
+                self.assertNotIn(
+                    "..",
+                    content_disp,
+                    msg=f"Double-dot in Content-Disposition for type '{export_type}'",
+                )
+
+
+class ExportPandocCommandTests(TestCase):
+    """Pandoc command is built only from EXPORT_MAPPING trusted options."""
+
+    def setUp(self):
+        self.user = PersonFactory()
+        self.assay = AssayFactory(title="pandoc test assay")
+        self.request = MagicMock()
+
+    def test_pandoc_command_contains_only_mapped_options(self):
+        """subprocess.run receives exactly the trusted options listed in EXPORT_MAPPING."""
+        from toxtempass.export import export_assay_to_file
+
+        for export_type in PANDOC_EXPORT_TYPES:
+            with (
+                self.subTest(export_type=export_type),
+                tempfile.TemporaryDirectory() as tmp_dir,
+            ):
+                yaml_stub = Path(tmp_dir) / "meta.yaml"
+                yaml_stub.write_text("title: test")
+                captured_commands: list = []
+
+                with (
+                    patch("toxtempass.export.settings") as mock_settings,
+                    patch("toxtempass.export.Config") as mock_config,
+                    patch(
+                        "toxtempass.export.generate_markdown_from_assay",
+                        return_value="# test",
+                    ),
+                    patch(
+                        "toxtempass.export.get_create_meta_data_yaml",
+                        return_value=yaml_stub,
+                    ),
+                    patch(
+                        "toxtempass.export.subprocess.run",
+                        side_effect=_make_pandoc_stub(captured_commands),
+                    ),
+                ):
+                    mock_settings.MEDIA_ROOT = tmp_dir
+                    mock_config.allowed_export_types = list(EXPORT_MAPPING.keys())
+                    export_assay_to_file(self.request, self.assay, export_type)
+
+                self.assertEqual(
+                    len(captured_commands),
+                    1,
+                    msg=f"Expected one subprocess.run call for type '{export_type}'",
+                )
+                cmd = captured_commands[0]
+
+                # Every trusted option from EXPORT_MAPPING must appear in the command
+                for opt in EXPORT_MAPPING[export_type]:
+                    self.assertIn(
+                        opt,
+                        cmd,
+                        msg=f"Trusted option '{opt}' missing from pandoc cmd for '{export_type}'",
+                    )
+
+                # The raw export_type string must NOT be a standalone argument
+                self.assertNotIn(
+                    export_type,
+                    cmd,
+                    msg=f"Raw export_type '{export_type}' must not appear as a standalone "
+                    f"argument in the pandoc command",
+                )


### PR DESCRIPTION
Potential fix for [https://github.com/johannehouweling/ToxTempAssistant/security/code-scanning/7](https://github.com/johannehouweling/ToxTempAssistant/security/code-scanning/7)

To address the uncontrolled command line risk, we should ensure that all values derived from user input used in filename construction and passed to subprocess commands are tightly mapped to hardcoded values. Rather than branching on the user-provided `export_type` and directly appending it to command arrays and filenames, we should use an explicit dictionary mapping each allowed export type to its respective pandoc output argument(s) and file extension, and construct filenames using only hardcoded extensions.

**Steps:**
- Create a dictionary that maps allowed `export_type` values to trusted Pandoc arguments (e.g., "md": ["--to=gfm+smart"]) and file extensions.
- Use this mapping to append only trusted options to the `pandoc_command` list.
- Also use the mapping for the filename construction, avoiding direct concatenation of `export_type` to the filename (e.g., use a mapped extension).
- If a type is not in the mapping, return an error early.
- All places where `export_type` is used must be sanitized to ensure it is only ever referenced via its mapping entry—never via direct string concatenation, interpolation, or unchecked conditional logic.

You do not need to change the allowlist check itself, but you do need to ensure that exported filenames and command line construction are tightly bound to hardcoded mappings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
