### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published] # fires whenever a new GitHub Release is published
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/johannehouweling/ToxTempAssistant/security/code-scanning/29](https://github.com/johannehouweling/ToxTempAssistant/security/code-scanning/29)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged.  
Best minimal fix here is at the workflow root (applies to all jobs): set `contents: read`. This satisfies CodeQL’s recommendation and should not change existing behavior, since checkout via PAT and deployment via SSH do not require `GITHUB_TOKEN` write access in the shown snippet.

**File to change:** `.github/workflows/deploy.yml`  
**Region:** after `on:` block (before `jobs:`), add:

```yml
permissions:
  contents: read
```

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
