### PR TITLE
feat(gold_standard): add --no-cosine prod read + local enrich_gold_cosines

### DIFF
--- a/myocyte/toxtempass/evaluation/gold_standard/README.md
+++ b/myocyte/toxtempass/evaluation/gold_standard/README.md
@@ -38,51 +38,64 @@ measures gpt-4o-mini's draft quality against human ground truth.
 ## Safety
 Strictly read-only: DB reads run in a `SET TRANSACTION READ ONLY` transaction with
 `pre_save`/`pre_delete`/`m2m_changed` write-tripwires; embeddings run *after* the transaction
-closes (no DB snapshot held during API calls); no MinIO/object access.
+closes (no DB snapshot held during API calls); no MinIO/object access. With `--no-cosine`
+(the production default below) **no embeddings run at all** — prod does a pure DB read and
+the cosine typing is computed locally.
 
 ## Run — local / dev
 ```bash
 # read-only; --limit for a quick pass; default output is output/gold_answers_<ts>.csv
-python manage.py extract_gold_answers --exclude-emails test@x.org --limit 3
+python manage.py extract_gold_answers --limit 3
 ```
 `--out` accepts a file (used verbatim) or a directory (gets a timestamped name); with no
 `--out` it writes `output/gold_answers_<YYYYMMDD_HHMM>.csv`. `output/` is gitignored — the
-CSV (answer text + reviewer emails) never reaches git.
+CSV (answer text + reviewer emails) never reaches git. Add `--no-cosine` to skip the
+embedding pass (then type it with `enrich_gold_cosines`, as in production below).
 
-## Run — production (runbook)
+## Run — production (the split: read on prod, type locally)
 
-The real data is on the production Postgres. Code reaches prod by **merging to `main`**,
-which auto-cuts a release and redeploys the legacy host (`deploy.yml`); watch the GitHub
-**Actions** tab for `Release` → `Publish image` → `Deploy` to go green (~5–15 min).
+Prod has **no OpenAI embeddings credential** — the chat models are Azure Foundry, whose key
+401s against `api.openai.com`, and Azure doesn't serve `text-embedding-3-large`. So the prod
+step runs **`--no-cosine`**: a pure read-only DB dump, **no key needed**. The cosine
+edit-typing is then computed on your machine, where the OpenAI key + the SHA embedding cache
+live. The typed result is identical to an inline run — it's just split in two.
 
-Then, on the prod host (the user is not in the `docker` group, so `sudo`; use `docker exec`
-with the explicit container name `djangoapp`, not `docker compose`, to avoid `GIT_TAG`
-warnings and container ambiguity). Replace the excluded emails as needed.
+Code reaches prod by **merging to `main`** (auto-release → `Publish image` → `Deploy`,
+~5–15 min on the Actions tab). Then, on the prod host (not in the `docker` group, so `sudo`;
+explicit container name `djangoapp`, not `docker compose`):
 
 ```bash
-# 1) extract (read-only; first run embeds pre-2025-09-13 drafts via OpenAI, then SHA-cached)
-sudo docker exec djangoapp python manage.py extract_gold_answers \
-  --exclude-emails christophe.vissers@rivm.nl --out /tmp/gold.csv
+# 1) extract — READ-ONLY, no OpenAI key, no API calls (one physical line)
+sudo docker exec djangoapp python manage.py extract_gold_answers --no-cosine --out /tmp/gold.csv
 
 # 2) copy it out of the container and make it readable
 sudo docker cp djangoapp:/tmp/gold.csv /home/$USER/gold.csv && sudo chmod 644 /home/$USER/gold.csv
 ```
 ```bash
-# 3) on your LOCAL machine, pull it down, then file it (gitignored) with a dated name
-scp <user>@<prod-host>:/home/<user>/gold.csv ~/Downloads/gold.csv
-mv ~/Downloads/gold.csv <repo>/myocyte/toxtempass/evaluation/gold_standard/output/gold_answers_<date>.csv
+# 3) on your LOCAL machine, pull it down (gitignored landing spot)
+scp <user>@<prod-host>:/home/<user>/gold.csv ~/Downloads/gold_no_cosine.csv
+
+# 4) fill the cosine edit-typing locally (uses your OpenAI key + SHA cache), writing to output/
+cd myocyte && poetry run python manage.py enrich_gold_cosines --in ~/Downloads/gold_no_cosine.csv --out toxtempass/evaluation/gold_standard/output/gold_answers_<date>.csv
 ```
 ```bash
-# 4) wipe the prod copies — the CSV holds gold answers + reviewer emails (PII)
+# 5) wipe the prod copies — the CSV holds gold answers + reviewer emails (PII)
 sudo docker exec djangoapp rm -f /tmp/gold.csv && sudo rm -f /home/$USER/gold.csv
 ```
 
-**Fallback** if step 1 prints `Unknown command: extract_gold_answers`, the running container
-is still the old image — from the repo dir on prod: `sudo docker compose --profile prod pull
-djangoapp && sudo docker compose --profile prod up -d djangoapp`, then retry.
+No `--exclude-emails` by default: demo assays are already filtered in code, and `owner_email`
+is a column, so drop any genuine test accounts during analysis rather than risk losing real
+reviewers. Add `--exclude-emails a@x,b@y` only for known dummy accounts.
 
-**Tip (paste mangling):** keep each command on ONE physical line; for the `mv`, `cd` into
-`output/` first, then `mv ~/Downloads/gold.csv gold_answers_<date>.csv`.
+**Inline (with-cosine) alternative:** if a valid OpenAI key is available to the container
+(`-e OPENAI_API_KEY=sk-…`), drop `--no-cosine` and skip steps 3–4 — the extract types inline.
+The split is preferred so no key ever touches prod.
+
+**Fallback** if step 1 prints `Unknown command` / `unrecognized arguments: --no-cosine`, the
+container is still the old image — from the repo dir on prod: `sudo docker compose --profile
+prod pull djangoapp && sudo docker compose --profile prod up -d djangoapp`, then retry.
+
+**Tip (paste mangling):** keep each command on ONE physical line.
 
 The companion **sufficiency** check (how much gold exists, by whom, with what docs) is
 `python manage.py assess_ground_truth` — same read-only / prod-ops pattern.
@@ -91,9 +104,10 @@ The companion **sufficiency** check (how much gold exists, by whom, with what do
 ```
 gold_standard/
   edit_analysis.py   # pure logic (draft detection + cosine edit-typing); unit-tested
-  audit.py           # read-only orchestrator; exposes run()
+  audit.py           # read-only orchestrator; exposes run() (--no-cosine skips embeddings)
+  enrich.py          # local pass: fill cosine + edit type for a --no-cosine CSV
   output/            # gitignored CSV + _embeddings/ cache
   README.md
+# commands: extract_gold_answers (prod, read-only) · enrich_gold_cosines (local, typing)
 # tests: toxtempass/tests/test_gold_standard_edit_analysis.py
-# command: toxtempass/management/commands/extract_gold_answers.py
 ```

--- a/myocyte/toxtempass/evaluation/gold_standard/audit.py
+++ b/myocyte/toxtempass/evaluation/gold_standard/audit.py
@@ -189,7 +189,9 @@ def run(opts: dict | None = None) -> dict:
 
     # Phase 2 — embeddings (outside the DB txn; SHA-cached, deterministic). The cache is
     # saved in `finally` so a partial run still persists computed vectors (free re-runs).
-    cosine_fn, cache = _make_cosine_fn()
+    # --no-cosine skips embeddings entirely (pure DB read, no OpenAI key): the baseline is
+    # still recovered, and cosine + edit type are filled later by ``enrich_gold_cosines``.
+    cosine_fn, cache = (None, None) if opts.get("no_cosine") else _make_cosine_fn()
     try:
         for r in records:
             gold = r["gold_answer"]
@@ -212,7 +214,8 @@ def run(opts: dict | None = None) -> dict:
                 }
             )
     finally:
-        cache.save()
+        if cache is not None:
+            cache.save()
 
     # Phase 3 — write + summarise.
     if opts.get("out"):

--- a/myocyte/toxtempass/evaluation/gold_standard/edit_analysis.py
+++ b/myocyte/toxtempass/evaluation/gold_standard/edit_analysis.py
@@ -94,14 +94,16 @@ def analyze_answer_history(
     rows: list[dict],
     final_text: str,
     not_found_str: str,
-    cosine_fn: CosineFn,
+    cosine_fn: CosineFn | None,
 ) -> dict[str, Any]:
     """Compute the baseline→accepted edit delta for one answer, for ANY history shape.
 
     ``rows`` are the answer's ``HistoricalAnswer`` dicts with keys ``answer_text``,
     ``history_type`` ('+'/'~'/'-'), ``history_user_id``, ``history_date``. ``final_text``
     is the live accepted answer. ``cosine_fn(a, b)`` returns the semantic cosine (inject
-    the project's cached embedding similarity).
+    the project's cached embedding similarity). Pass ``cosine_fn=None`` to skip the
+    embedding call (the ``--no-cosine`` prod path): the baseline is still recovered, but
+    ``change_type`` / ``cosine_baseline_final`` are left blank for a later local pass.
 
     Baseline (see module docstring): the gpt-4o-mini draft if a non-blank ``~`` snapshot
     with ``history_user_id is None`` exists (``baseline_kind='model_draft'``,
@@ -155,16 +157,20 @@ def analyze_answer_history(
 
     if baseline_row is not None:
         baseline = baseline_row.get("answer_text") or ""
-        cos = cosine_fn(baseline, final_text)
-        c = classify_edit(baseline, final_text, cos, not_found_str)
-        out.update(
-            baseline_kind=kind,
-            delta_exact=exact,
-            baseline_answer=baseline,
-            change_type=c["edit_type"],
-            cosine_baseline_final=c["cosine"],
-            lexical_ratio_baseline_final=c["lexical_ratio"],
-            chars_added=c["chars_added"],
-            chars_removed=c["chars_removed"],
-        )
+        out.update(baseline_kind=kind, delta_exact=exact, baseline_answer=baseline)
+        if cosine_fn is None:
+            # --no-cosine: recover the baseline only; cosine + edit type are filled later
+            # by the local pass. Blank (not "n/a", which signals "no baseline at all").
+            out["change_type"] = ""
+        else:
+            c = classify_edit(
+                baseline, final_text, cosine_fn(baseline, final_text), not_found_str
+            )
+            out.update(
+                change_type=c["edit_type"],
+                cosine_baseline_final=c["cosine"],
+                lexical_ratio_baseline_final=c["lexical_ratio"],
+                chars_added=c["chars_added"],
+                chars_removed=c["chars_removed"],
+            )
     return out

--- a/myocyte/toxtempass/evaluation/gold_standard/enrich.py
+++ b/myocyte/toxtempass/evaluation/gold_standard/enrich.py
@@ -1,0 +1,72 @@
+"""Local cosine enrichment for a ``--no-cosine`` gold CSV (the second half of the split).
+
+``extract_gold_answers --no-cosine`` runs pure-DB on prod (no OpenAI key) and emits the
+gold + recovered baseline (draft) text with the semantic columns left blank. This step
+fills them on your machine, where the OpenAI key + SHA embedding cache live: it computes
+cosine(baseline, gold) and the full edit type for every row that has a recovered baseline.
+Reproducible and cheap on re-run (embeddings are SHA-cached in ``output/_embeddings``).
+
+    cd myocyte && poetry run python manage.py enrich_gold_cosines \
+        --in gold_no_cosine.csv --out gold_typed.csv
+"""
+
+from __future__ import annotations
+
+import csv
+from collections import Counter
+
+from toxtempass import config
+from toxtempass.evaluation.gold_standard import audit
+from toxtempass.evaluation.gold_standard.edit_analysis import classify_edit
+
+NOT_FOUND = config.not_found_string
+
+
+def _is_exact(row: dict) -> bool:
+    """Return True when the delta is exact (baseline = recovered model draft)."""
+    return str(row.get("delta_exact")).strip().lower() == "true"
+
+
+def run_enrich(in_path: str, out_path: str) -> dict:
+    """Fill cosine + edit type per baseline→gold row of a --no-cosine CSV; write it out.
+
+    Reuses the same SHA-cached embedding cosine and the same ``classify_edit`` taxonomy as
+    the inline (with-cosine) extract, so the typed output is identical to a direct run —
+    just computed locally. Rows without a recovered baseline are passed through untouched.
+    """
+    with open(in_path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+
+    cosine_fn, cache = audit._make_cosine_fn()
+    typed = 0
+    try:
+        for r in rows:
+            baseline = r.get("baseline_answer") or ""
+            if (r.get("baseline_kind") or "none") == "none" or not baseline.strip():
+                continue
+            gold = r.get("gold_answer") or ""
+            c = classify_edit(baseline, gold, cosine_fn(baseline, gold), NOT_FOUND)
+            r["change_type"] = c["edit_type"]
+            r["cosine_baseline_final"] = c["cosine"]
+            r["lexical_ratio_baseline_final"] = c["lexical_ratio"]
+            r["chars_added"] = c["chars_added"]
+            r["chars_removed"] = c["chars_removed"]
+            typed += 1
+    finally:
+        cache.save()
+
+    with open(out_path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=audit.CSV_COLUMNS, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+    return {
+        "n_rows": len(rows),
+        "n_typed": typed,
+        "change_type_counts_all": dict(
+            Counter(r.get("change_type") or "n/a" for r in rows)
+        ),
+        "change_type_counts_exact": dict(
+            Counter(r.get("change_type") or "n/a" for r in rows if _is_exact(r))
+        ),
+    }

--- a/myocyte/toxtempass/management/commands/enrich_gold_cosines.py
+++ b/myocyte/toxtempass/management/commands/enrich_gold_cosines.py
@@ -1,0 +1,65 @@
+"""Thin command: locally fill the cosine edit-typing for a --no-cosine gold CSV.
+
+Pairs with ``extract_gold_answers --no-cosine`` (prod, pure DB read, no OpenAI key). This
+runs on your machine, where the OpenAI key + SHA embedding cache live. Logic lives in
+``toxtempass.evaluation.gold_standard.enrich``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError, CommandParser
+from django.utils import timezone
+
+from toxtempass.evaluation.gold_standard import enrich
+
+
+def _resolve_out(in_path: str, out: str) -> str:
+    """Resolve the output CSV path (file verbatim; directory → timestamped name)."""
+    ts = timezone.now().strftime("%Y%m%d_%H%M")
+    if not out:
+        p = Path(in_path)
+        return str(p.with_name(f"{p.stem}_typed_{ts}.csv"))
+    p = Path(out)
+    return str(p / f"gold_typed_{ts}.csv") if p.is_dir() else out
+
+
+class Command(BaseCommand):
+    """Locally fill cosine + edit type for a --no-cosine gold CSV (uses OpenAI key)."""
+
+    help = "Locally fill cosine edit-typing for a --no-cosine gold CSV."
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        """Register CLI options."""
+        parser.add_argument(
+            "--in",
+            dest="in_path",
+            required=True,
+            help="Path to the --no-cosine gold CSV from extract_gold_answers.",
+        )
+        parser.add_argument(
+            "--out",
+            default="",
+            help="Output path (file used verbatim; a directory gets a timestamped name).",
+        )
+
+    def handle(self, *args: object, **options: object) -> None:
+        """Run the local enrichment and print the change-type distribution."""
+        in_path = str(options["in_path"])
+        if not Path(in_path).is_file():
+            raise CommandError(f"--in file not found: {in_path}")
+        out_path = _resolve_out(in_path, str(options["out"]))
+        summary = enrich.run_enrich(in_path, out_path)
+        w = self.stdout.write
+        w("")
+        w("GOLD COSINE ENRICHMENT  (local)")
+        w(f"  rows                 : {summary['n_rows']}")
+        w(f"  typed (had baseline) : {summary['n_typed']}")
+        w("  change types (exact-delta subset):")
+        for t, n in sorted(
+            summary["change_type_counts_exact"].items(), key=lambda kv: -kv[1]
+        ):
+            w(f"    {t:18} {n}")
+        w(f"  wrote CSV → {out_path}")
+        w("")

--- a/myocyte/toxtempass/management/commands/extract_gold_answers.py
+++ b/myocyte/toxtempass/management/commands/extract_gold_answers.py
@@ -53,16 +53,24 @@ class Command(BaseCommand):
         parser.add_argument(
             "--out", default="", help="Path to write the gold + edit-analysis CSV."
         )
+        parser.add_argument(
+            "--no-cosine",
+            action="store_true",
+            help="Pure DB read — skip embeddings/cosine (no OpenAI key needed). Fill the "
+            "edit-typing afterwards, locally, with enrich_gold_cosines.",
+        )
 
     def handle(self, *args: object, **options: object) -> None:
         """Run the audit and print the headline summary."""
         out_path = _resolve_out(str(options["out"]))
+        no_cosine = bool(options["no_cosine"])
         summary = audit.run(
             {
                 "exclude_emails": options["exclude_emails"],
                 "min_accepted": options["min_accepted"],
                 "limit": options["limit"],
                 "out": out_path,
+                "no_cosine": no_cosine,
             }
         )
         w = self.stdout.write
@@ -72,10 +80,15 @@ class Command(BaseCommand):
         w(f"  assays                            : {summary['n_assays']}")
         w(f"  delta EXACT (model draft recovered): {summary['n_delta_exact']}")
         w(f"  delta LOWER-BOUND (1st human save) : {summary['n_delta_lower_bound']}")
-        w("  change types (exact-delta subset):")
-        for t, n in sorted(
-            summary["change_type_counts_exact"].items(), key=lambda kv: -kv[1]
-        ):
-            w(f"    {t:18} {n}")
+        if no_cosine:
+            w("  edit-typing                       : DEFERRED (--no-cosine, no API)")
+            w("    next, locally (where the OpenAI key lives), run:")
+            w("      manage.py enrich_gold_cosines --in <this>.csv --out <typed>.csv")
+        else:
+            w("  change types (exact-delta subset):")
+            for t, n in sorted(
+                summary["change_type_counts_exact"].items(), key=lambda kv: -kv[1]
+            ):
+                w(f"    {t:18} {n}")
         w(f"  wrote CSV → {out_path}")
         w("")

--- a/myocyte/toxtempass/tests/test_gold_standard_edit_analysis.py
+++ b/myocyte/toxtempass/tests/test_gold_standard_edit_analysis.py
@@ -111,6 +111,23 @@ def test_baseline_first_human_save_is_lower_bound():
     assert b["change_type"] != "n/a"            # a delta IS computed (lower bound)
 
 
+def test_no_cosine_defers_typing():
+    # --no-cosine (cosine_fn=None): the baseline is still recovered, but cosine + change
+    # type are left blank for the local enrich pass (blank, NOT "n/a" = no baseline).
+    d = date(2025, 1, 1)
+    rows = [
+        _row("", "+", 1, d),
+        _row("the gpt-4o-mini draft", "~", None, d),
+        _row("scientist edited final", "~", 7, d),
+    ]
+    a = analyze_answer_history(rows, "scientist edited final", NF, None)
+    assert a["baseline_kind"] == "model_draft"
+    assert a["delta_exact"] is True
+    assert a["baseline_answer"] == "the gpt-4o-mini draft"
+    assert a["change_type"] == ""
+    assert a["cosine_baseline_final"] == ""
+
+
 def test_saved_once_lower_bound_zero_delta():
     # Saved once (first non-blank == final): lower-bound delta is 0 (no post-save edits),
     # but it's still flagged lower-bound — not provably the verbatim draft.


### PR DESCRIPTION
Prod has no OpenAI embeddings credential (the Azure Foundry key 401s against api.openai.com, and Azure doesn't serve text-embedding-3-large), so the inline cosine pass crashed. Split the extract: `extract_gold_answers --no-cosine` does a pure read-only DB dump (no key, no API) that still recovers the baseline draft, and the new local `enrich_gold_cosines` command fills cosine + edit type from the OpenAI key + SHA cache. `analyze_answer_history` now accepts `cosine_fn=None`. The typed result is identical to an inline run.